### PR TITLE
Dev 3.0.0

### DIFF
--- a/OpenBCI_32bit_Library_Definitions.h
+++ b/OpenBCI_32bit_Library_Definitions.h
@@ -338,6 +338,7 @@
 #define OPENBCI_WIFI_ATTACH '{'
 #define OPENBCI_WIFI_REMOVE '}'
 #define OPENBCI_WIFI_STATUS ':'
+#define OPENBCI_WIFI_RESET ';'
 
 /** Possible number of channels */
 #define OPENBCI_NUMBER_OF_CHANNELS_DAISY 16

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * Removed `sniffMode` in place for `curBoardMode == OPENBCI_BOARD_MODE_DEBUG`
 * Removed public `waitForNewChannelData()`
 * Removed public `timeSynced` and private `sendTimeSyncUpPacket`
+* Setting internal test signal now, when not streaming, returns a success message, with EOT `$$$`
 
 # v2.0.1
 


### PR DESCRIPTION
* Setting internal test signal now, when not streaming, returns a success message, with EOT `$$$`