### PR TITLE
Dev 3.0.0

### DIFF
--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -271,6 +271,8 @@ private:
   void    RREGS(byte,byte,int);      // read multiple ADS registers
   void    SDATAC(int);  // get out of read data continuous mode
   void    sendChannelDataSerial(PACKET_TYPE);
+  void    sendTimeWithAccelSerial(void);
+  void    sendTimeWithRawAuxSerial(void);
   void    STANDBY(int); // go into low power mode
   void    START(int);   // start data acquisition
   void    STOP(int);    // stop data acquisition
@@ -310,8 +312,6 @@ private:
   void    sendChannelDataWifi(PACKET_TYPE, boolean);
   void    sendRawAuxWifi(void);
   void    sendTimeWithAccelWifi(void);
-  void    sendTimeWithAccelSerial(void);
-  void    sendTimeWithRawAuxSerial(void);
   void    sendTimeWithRawAuxWifi(void);
 #endif
 };

--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -8,6 +8,8 @@ insert header here
 
 #include <DSPI.h>
 #include <Arduino.h>
+#include <OpenBCI_Wifi_Master.h>
+#include <OpenBCI_Wifi_Master_Definitions.h>
 #include "OpenBCI_32bit_Library_Definitions.h"
 
 void __USER_ISR ADS_DRDY_Service(void);
@@ -223,12 +225,12 @@ public:
   // Class Objects
   DSPI0 spi;  // use DSPI library
 
-#ifdef __OpenBCI_Wifi_Master__
+// #ifdef __OpenBCI_Wifi_Master__
   void    accelWriteAxisDataWifi(void);
   void    ADS_writeChannelDataWifi(boolean daisy);
   void    writeAuxDataWifi(void);
   void    writeTimeCurrentWifi(uint32_t newTime);
-#endif
+// #endif
 
 private:
 

--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -69,13 +69,11 @@ public:
   boolean accelHasNewData(void);
   void    accelUpdateAxisData(void);
   void    accelWriteAxisDataSerial(void);
-  void    accelWriteAxisDataWifi(void);
   void    activateAllChannelsToTestCondition(byte testInputCode, byte amplitudeCode, byte freqCode);
   void    activateChannel(byte);                  // enable the selected channel
   void    ADS_writeChannelData(void);
   void    ADS_writeChannelDataAvgDaisy(void);
   void    ADS_writeChannelDataNoAvgDaisy(void);
-  void    ADS_writeChannelDataWifi(boolean daisy);
   void    attachDaisy(void);
   void    begin(void);
   void    beginDebug(void);
@@ -165,32 +163,14 @@ public:
   void    updateDaisyData(boolean);
   void    useAccel(boolean);
   void    useTimeStamp(boolean);
-  boolean wifiAttach(void);
-  void    wifiBufferTxClear(void);
-  void    wifiBufferRxClear(void);
-  void    wifiFlushBufferTx(void);
-  void    wifiReadData(void);
-  uint32_t wifiReadStatus(void);
-  boolean wifiRemove(void);
-  void    wifiReset(void);
-  void    wifiSendGains(void);
-  void    wifiSendStringMulti(const char *);
-  void    wifiSendStringLast();
-  void    wifiSendStringLast(const char *);
-  void    wifiSetInfo(SpiInfo, boolean, boolean);
-  boolean wifiSmell(void);
-  boolean wifiStoreByteBufTx(uint8_t);
-  void    wifiWriteData(uint8_t *, size_t);
   void    write(uint8_t);
   void    writeAuxDataSerial(void);
-  void    writeAuxDataWifi(void);
   void    writeChannelSettings(void);
   void    writeChannelSettings(byte);
   void    writeSerial(uint8_t);
   void    writeSpi(uint8_t);
   void    writeTimeCurrent(void);
   void    writeTimeCurrentSerial(uint32_t newTime);
-  void    writeTimeCurrentWifi(uint32_t newTime);
   void    writeZeroAux(void);
   void    zeroAuxData(void);
 
@@ -202,7 +182,6 @@ public:
   boolean useInBias[OPENBCI_NUMBER_OF_CHANNELS_DAISY];        // used to remember if we were included in Bias before channel power down
   boolean useSRB2[OPENBCI_NUMBER_OF_CHANNELS_DAISY];
   boolean verbosity; // turn on/off Serial verbosity
-  boolean wifiPresent;
 
   byte boardChannelDataRaw[OPENBCI_NUMBER_BYTES_PER_ADS_SAMPLE];    // array to hold raw channel data
   byte channelSettings[OPENBCI_NUMBER_OF_CHANNELS_DAISY][OPENBCI_NUMBER_OF_CHANNEL_SETTINGS];  // array to hold current channel settings
@@ -226,10 +205,6 @@ public:
   short auxData[3]; // This is user faceing
   short axisData[3];
 
-  uint8_t wifiBufferTx[WIFI_SPI_MAX_PACKET_SIZE];
-  char wifiBufferRx[WIFI_SPI_MAX_PACKET_SIZE];
-  uint8_t wifiBufferTxPosition;
-
   unsigned long lastSampleTime;
 
   volatile boolean channelDataAvailable;
@@ -244,10 +219,16 @@ public:
   // STRUCTS
   SerialInfo iSerial0;
   SerialInfo iSerial1;
-  SpiInfo iWifi;
 
   // Class Objects
   DSPI0 spi;  // use DSPI library
+
+#ifdef __OpenBCI_Wifi_Master__
+  void    accelWriteAxisDataWifi(void);
+  void    ADS_writeChannelDataWifi(boolean daisy);
+  void    writeAuxDataWifi(void);
+  void    writeTimeCurrentWifi(uint32_t newTime);
+#endif
 
 private:
 
@@ -274,19 +255,15 @@ private:
   boolean LIS3DH_DataAvailable(void); // check LIS3DH STATUS_REG2
   void    LIS3DH_readAllRegs(void);
   void    LIS3DH_writeAxisDataSerial(void);
-  void    LIS3DH_writeAxisDataWifi(void);
   void    LIS3DH_writeAxisDataForAxisSerial(uint8_t);
-  void    LIS3DH_writeAxisDataForAxisWifi(uint8_t);
   void    LIS3DH_updateAxisData(void);
   void    LIS3DH_zeroAxisData(void);
-  boolean processCharWifi(char character);
   void    printADSregisters(int);
   void    printAllRegisters(void);
   void    printFailure();
   void    printHex(byte);
   void    printRegisterName(byte);
   void    printSuccess();
-  void    processCharWifi(uint8_t);
   void    RDATA(int);   // read data one-shot
   void    RDATAC(int);  // go into read data continuous mode
   void    RESET(int);   // set all register values to default
@@ -294,12 +271,6 @@ private:
   void    RREGS(byte,byte,int);      // read multiple ADS registers
   void    SDATAC(int);  // get out of read data continuous mode
   void    sendChannelDataSerial(PACKET_TYPE);
-  void    sendChannelDataWifi(PACKET_TYPE, boolean);
-  void    sendRawAuxWifi(void);
-  void    sendTimeWithAccelWifi(void);
-  void    sendTimeWithAccelSerial(void);
-  void    sendTimeWithRawAuxSerial(void);
-  void    sendTimeWithRawAuxWifi(void);
   void    STANDBY(int); // go into low power mode
   void    START(int);   // start data acquisition
   void    STOP(int);    // stop data acquisition
@@ -316,10 +287,6 @@ private:
   boolean isRunning;
   boolean settingBoardMode;
   boolean settingSampleRate;
-  boolean toggleWifiCS;
-  boolean toggleWifiReset;
-  boolean soughtWifiShield;
-  boolean seekingWifi;
   byte    regData[24]; // array is used to mirror register data
   char    buffer[1];
   char    currentChannelSetting;
@@ -333,11 +300,20 @@ private:
   int     numberOfIncomingSettingsProcessedChannel;
   int     numberOfIncomingSettingsProcessedLeadOff;
   int     numberOfIncomingSettingsProcessedBoardType;
-  int     wifiAttachAttempts;
   uint8_t optionalArgCounter;
   unsigned long timeOfLastRead;
-  unsigned long timeOfWifiToggle;
-  unsigned long timeOfWifiStart;
+
+#ifdef __OpenBCI_Wifi_Master__
+  // functions
+  void    LIS3DH_writeAxisDataWifi(void);
+  void    LIS3DH_writeAxisDataForAxisWifi(uint8_t);
+  void    sendChannelDataWifi(PACKET_TYPE, boolean);
+  void    sendRawAuxWifi(void);
+  void    sendTimeWithAccelWifi(void);
+  void    sendTimeWithAccelSerial(void);
+  void    sendTimeWithRawAuxSerial(void);
+  void    sendTimeWithRawAuxWifi(void);
+#endif
 };
 
 // This let's us call into the class from within the library if necessary

--- a/OpenBCI_32bit_Library_Definitions.h
+++ b/OpenBCI_32bit_Library_Definitions.h
@@ -26,10 +26,10 @@
 #define SD_SS 2  	          // SD card chip select
 #define LIS3DH_SS	1         // LIS3DH chip select
 #define LIS3DH_DRDY 0	      // LIS3DH data ready pin
-#define WIFI_SS 13          // Wifi Chip Select
+// #define WIFI_SS 13          // Wifi Chip Select
 #define OPENBCI_PIN_LED 11
 #define OPENBCI_PIN_PGC 12
-#define WIFI_RESET 18
+// #define WIFI_RESET 18
 
 #define OPENBCI_PIN_SERIAL1_TX 11
 #define OPENBCI_PIN_SERIAL1_RX 12
@@ -376,16 +376,5 @@
 
 #define OPENBCI_ADS_BYTES_PER_CHAN 3
 #define OPENBCI_ADS_CHANS_PER_BOARD 8
-
-// WIFI SPI stuff
-#define WIFI_SPI_CMD_NULL 0x00
-#define WIFI_SPI_CMD_DATA_READ 0x03
-#define WIFI_SPI_CMD_DATA_WRITE 0x02
-#define WIFI_SPI_CMD_STATUS_READ 0x04
-#define WIFI_SPI_CMD_STATUS_WRITE 0x01
-#define WIFI_SPI_MAX_PACKET_SIZE 32
-#define WIFI_SPI_MSG_LAST 0x01
-#define WIFI_SPI_MSG_MULTI 0x02
-#define WIFI_SPI_MSG_GAINS 0x03
 
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,11 @@
 
 ### New Features
 
-* Add wifi shield support
+* Add wifi shield support.
+   * Simply add [OpenBCI_Wifi_Master](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library) to your `DefaultBoard.ino` and add `wifi.loop()` to your loop function. If you want to read from it checkout the `DefaultBoard.ino` for it's simple interface.
    * Send channel gains to wifi shield at start of stream
    * takes ~4 seconds for the wifi shield to be reachable
 * Add ability to turn external serial port `Serial1` on through commands.
-* Add ability to use ESP8266 through SPI port.
 * Change board types on the fly! No longer do you have to upload new code to the Cyton's Pic32 just to do an analog read. You can now read from analog or digital pins with the press send of a code! `/` now sets the board mode, where:
    * BOARD_MODE_DEFAULT is `0`
    * BOARD_MODE_DEBUG is `1`

--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,33 @@
 * Removed public `timeSynced` and private `sendTimeSyncUpPacket`
 * Setting internal test signal now, when not streaming, returns a success message, with EOT `$$$`
 
+## Beta3
+
+The overall goal was to clean the wifi code out of the library so it would not be needed when you are building a bare board. 
+
+### Bug Fixes
+
+* Fixed the `BoardWithAnalogSensor.ino`, `BoardWithDigitalRead.ino` and `BoardWithCustomData.ino` examples.
+
+### Breaking Changes
+
+* Removed all wifi code and put into [new library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library) that must be included! The new library is a called [OpenBCI_Wifi_Master_Library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library). It is simply included when wifi is wanted.
+* Removed `.loop()` function from library.
+
+### Files
+
+* Add `BoardWithWifi.ino` example that shows a bare board with just wifi. No SD or ACCEL for example.
+
+## Beta2
+
+### Breaking Changes
+
+* Setting internal test signal now, when not streaming, returns a success message, with EOT $$$
+
+## Beta1
+
+* Initial Release
+
 # v2.0.1
 
 ### Bug Fixes

--- a/examples/BoardNoAccelSDWifi/BoardNoAccelSDWifi.ino
+++ b/examples/BoardNoAccelSDWifi/BoardNoAccelSDWifi.ino
@@ -10,7 +10,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   if (board.streaming) {
     if (board.channelDataAvailable) {
       // Read from the ADS(s), store data, set channelDataAvailable flag to false

--- a/examples/BoardNoAccelSDWifiDebug/BoardNoAccelSDWifiDebug.ino
+++ b/examples/BoardNoAccelSDWifiDebug/BoardNoAccelSDWifiDebug.ino
@@ -10,7 +10,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   if (board.streaming) {
     if (board.channelDataAvailable) {
       // Read from the ADS(s), store data, set channelDataAvailable flag to false

--- a/examples/BoardWith2ButtonExternalTriggers/BoardWith2ButtonExternalTriggers.ino
+++ b/examples/BoardWith2ButtonExternalTriggers/BoardWith2ButtonExternalTriggers.ino
@@ -37,7 +37,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   if (board.streaming) {
     if (board.channelDataAvailable) {
       // Read from the ADS(s), store data, set channelDataAvailable flag to false

--- a/examples/BoardWithAccel/BoardWithAccel.ino
+++ b/examples/BoardWithAccel/BoardWithAccel.ino
@@ -11,7 +11,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   // The main dependency of this single threaded microcontroller is to
   //  stream data from the ADS.
   if (board.streaming) {

--- a/examples/BoardWithAnalogSensor/BoardWithAnalogSensor.ino
+++ b/examples/BoardWithAnalogSensor/BoardWithAnalogSensor.ino
@@ -14,11 +14,10 @@ void setup() {
   //  Aux 1:2 D11 (A5)
   //  Aux 3:4 D12 (A6)
   //  Aux 5:6 D17 (A7)
-  board.setBoardMode(BOARD_MODE_ANALOG);
+  board.setBoardMode(board.BOARD_MODE_ANALOG);
 }
 
 void loop() {
-  board.loop();
   // The main dependency of this single threaded microcontroller is to
   //  stream data from the ADS.
   if (board.streaming) {

--- a/examples/BoardWithCustomData/BoardWithCustomData.ino
+++ b/examples/BoardWithCustomData/BoardWithCustomData.ino
@@ -17,7 +17,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   // Downsample
   if ((millis() - timer) > 10) {
     // Save new time
@@ -49,7 +48,7 @@ void sendLEDStatus() {
   Serial0.write(LEDState); // 1 byte
   // Fill the rest with fake data
   for (int i = 0; i < 30; i++) {
-    Serial0.write(0x00);
+    Serial0.write((uint8_t)0x00);
   }
   // Send a stop byte with an `B` or `1011` in the last nibble to indicate a
   //  different packet type.

--- a/examples/BoardWithDigitalRead/BoardWithDigitalRead.ino
+++ b/examples/BoardWithDigitalRead/BoardWithDigitalRead.ino
@@ -12,11 +12,10 @@ void setup() {
   //  Aux 1:2 D11
   //  Aux 3:4 D12
   //  Aux 5:6 D17
-  board.setBoardMode(BOARD_MODE_DIGITAL);
+  board.setBoardMode(board.BOARD_MODE_DIGITAL);
 }
 
 void loop() {
-  board.loop();
   // The main dependency of this single threaded microcontroller is to
   //  stream data from the ADS.
   if (board.streaming) {

--- a/examples/BoardWithPulseSensor/BoardWithPulseSensor.ino
+++ b/examples/BoardWithPulseSensor/BoardWithPulseSensor.ino
@@ -46,7 +46,6 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
   // The main dependency of this single threaded microcontroller is to
   //  stream data from the ADS.
   if (board.streaming) {

--- a/examples/BoardWithWifi/BoardWithWifi.ino
+++ b/examples/BoardWithWifi/BoardWithWifi.ino
@@ -1,0 +1,50 @@
+#include <DSPI.h>
+#include <EEPROM.h>
+#include <OpenBCI_Wifi_Master_Definitions.h>
+#include <OpenBCI_Wifi_Master.h>
+#include <OpenBCI_32bit_Library.h>
+#include <OpenBCI_32bit_Library_Definitions.h>
+
+void setup() {
+  // Bring up the OpenBCI Board
+  board.begin();
+  // Bring up wifi with rx/tx both true
+  wifi.begin(true, true);
+}
+
+void loop() {
+  if (board.streaming) {
+    if (board.channelDataAvailable) {
+      // Read from the ADS(s), store data, set channelDataAvailable flag to false
+      board.updateChannelData();
+      // Send the channel data
+      board.sendChannelData();
+    }
+  }
+
+  // Call to wifi loop
+  wifi.loop();
+
+  // Check serial 0 for new data
+  if (board.hasDataSerial0()) {
+    // Read one char from the serial 0 port
+    char newChar = board.getCharSerial0();
+
+    // Send to the sd library for processing
+    sdProcessChar(newChar);
+
+    // Send to the board library
+    board.processChar(newChar);
+  }
+
+  if (wifi.hasData()) {
+    // Read one char from the wifi shield
+    char newChar = wifi.getChar();
+
+    // Send to the sd library for processing
+    sdProcessChar(newChar);
+
+    // Send to the board library
+    board.processChar(newChar);
+  }
+}

--- a/examples/DefaultBoard/DefaultBoard.ino
+++ b/examples/DefaultBoard/DefaultBoard.ino
@@ -1,6 +1,7 @@
 #include <DSPI.h>
 #include <OBCI32_SD.h>
 #include <EEPROM.h>
+#include <OpenBCI_Wifi_Master.h>
 #include <OpenBCI_32bit_Library.h>
 #include <OpenBCI_32bit_Library_Definitions.h>
 
@@ -15,7 +16,7 @@ void setup() {
 }
 
 void loop() {
-  board.loop();
+  wifi.loop();
   if (board.streaming) {
     if (board.channelDataAvailable) {
       // Read from the ADS(s), store data, set channelDataAvailable flag to false
@@ -64,6 +65,17 @@ void loop() {
     sdProcessChar(newChar);
 
     // Read one char and process it
+    board.processChar(newChar);
+  }
+
+  if (wifi.hasData()) {
+    // Read one char from the wifi shield
+    char newChar = wifi.getChar();
+
+    // Send to the sd library for processing
+    sdProcessChar(newChar);
+
+    // Send to the board library
     board.processChar(newChar);
   }
 }

--- a/examples/DefaultBoard/DefaultBoard.ino
+++ b/examples/DefaultBoard/DefaultBoard.ino
@@ -1,6 +1,8 @@
+#define USE_WIFI
 #include <DSPI.h>
 #include <OBCI32_SD.h>
 #include <EEPROM.h>
+#include <OpenBCI_Wifi_Master_Definitions.h>
 #include <OpenBCI_Wifi_Master.h>
 #include <OpenBCI_32bit_Library.h>
 #include <OpenBCI_32bit_Library_Definitions.h>

--- a/examples/DefaultBoard/DefaultBoard.ino
+++ b/examples/DefaultBoard/DefaultBoard.ino
@@ -1,4 +1,3 @@
-#define USE_WIFI
 #include <DSPI.h>
 #include <OBCI32_SD.h>
 #include <EEPROM.h>
@@ -15,10 +14,11 @@ boolean SDfileOpen = false; // Set true by SD_Card_Stuff.ino on successful file 
 void setup() {
   // Bring up the OpenBCI Board
   board.begin();
+  // Bring up wifi
+  wifi.begin(true, true);
 }
 
 void loop() {
-  wifi.loop();
   if (board.streaming) {
     if (board.channelDataAvailable) {
       // Read from the ADS(s), store data, set channelDataAvailable flag to false
@@ -47,6 +47,10 @@ void loop() {
       board.sendChannelData();
     }
   }
+
+  // Call to wifi loop
+  wifi.loop();
+
   // Check serial 0 for new data
   if (board.hasDataSerial0()) {
     // Read one char from the serial 0 port

--- a/libraries.properties
+++ b/libraries.properties
@@ -1,0 +1,9 @@
+name=OpenBCI_32bit_Library
+version=3.0.0-beta3
+author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
+maintainers=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
+sentence=The library for controlling OpenBCI 32bit boards. The Cyton is the main one.
+paragraph=The is meant to be ran on the Pic 32. Use the DefaultBoard.ino for the firmware that ships with every Cyton order. See the examples for stipped down versions of the board. See the learning pages at openbci.com for more info!
+category=Device Control
+url=https://github.com/OpenBCI/OpenBCI_32bit_Library
+architectures="*"


### PR DESCRIPTION
## Beta3

The overall goal was to clean the wifi code out of the library so it would not be needed when you are building a bare board. 

### Bug Fixes

* Fixed the `BoardWithAnalogSensor.ino`, `BoardWithDigitalRead.ino` and `BoardWithCustomData.ino` examples.

### Breaking Changes

* Removed all wifi code and put into [new library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library) that must be included! The new library is a called [OpenBCI_Wifi_Master_Library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library). It is simply included when wifi is wanted.
* Removed `.loop()` function from library.

### Files

* Add `BoardWithWifi.ino` example that shows a bare board with just wifi. No SD or ACCEL for example.