### PR TITLE
FIX: Board wrote to Serial0 even if command came from wifi

### DIFF
--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -448,6 +448,13 @@ boolean OpenBCI_32bit_Library::processChar(char character) {
   return true;
 }
 
+boolean OpenBCI_32bit_Library::processCharWifi(char character) {
+  commandFromSPI = true;
+  boolean retVal = processChar(character);
+  commandFromSPI = false;
+  return retVal;
+}
+
 /**
  * Used to turn on or off the accel, will change the current packet type!
  * @param yes {boolean} - True if you want to use it
@@ -564,7 +571,7 @@ boolean OpenBCI_32bit_Library::boardBeginDebug(int baudRate) {
   iSerial1.baudRate = baudRate;
   // setSerialInfo(iSerial1, true, true, OPENBCI_BAUD_RATE);
   // Serial0.print("begin S1 tx "); Serial0.println(iSerial1.tx ? "on" : "off");
-  Serial1.print("begin S1 tx "); Serial1.println(iSerial1.tx ? "on" : "off");
+  // Serial1.print("begin S1 tx "); Serial1.println(iSerial1.tx ? "on" : "off");
 
   curBoardMode = BOARD_MODE_DEBUG;
 
@@ -594,7 +601,7 @@ void OpenBCI_32bit_Library::boardReset(void) {
     printAll("On Daisy ADS1299 Device ID: 0x"); printlnHex(ADS_getDeviceID(ON_DAISY));
   }
   printAll("LIS3DH Device ID: 0x"); printlnHex(LIS3DH_getDeviceID());
-  printlnAll("Firmware: v3.0.0");
+  printlnAll("Firmware: v3.0.0-rc6");
   sendEOT();
   delay(5);
   wifi.reset();
@@ -993,6 +1000,7 @@ void __USER_ISR ADS_DRDY_Service() {
 void OpenBCI_32bit_Library::initializeVariables(void) {
   // Bools
   channelDataAvailable = false;
+  commandFromSPI = false;
   daisyPresent = false;
   isProcessingIncomingSettingsChannel = false;
   isProcessingIncomingSettingsLeadOff = false;
@@ -2613,7 +2621,7 @@ void OpenBCI_32bit_Library::stopADS()
 }
 
 void OpenBCI_32bit_Library::printSerial(int i) {
-  if (iSerial0.tx) {
+  if (iSerial0.tx && !commandFromSPI) {
     Serial0.print(i);
   }
   if (iSerial1.tx) {
@@ -2622,7 +2630,7 @@ void OpenBCI_32bit_Library::printSerial(int i) {
 }
 
 void OpenBCI_32bit_Library::printSerial(char c) {
-  if (iSerial0.tx) {
+  if (iSerial0.tx && !commandFromSPI) {
     Serial0.print(c);
   }
   if (iSerial1.tx) {
@@ -2631,7 +2639,7 @@ void OpenBCI_32bit_Library::printSerial(char c) {
 }
 
 void OpenBCI_32bit_Library::printSerial(int c, int arg) {
-  if (iSerial0.tx) {
+  if (iSerial0.tx && !commandFromSPI) {
     Serial0.print(c, arg);
   }
   if (iSerial1.tx) {

--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -132,6 +132,7 @@ public:
   void    printSerial(int, int);
   void    printSerial(const char *);
   boolean processChar(char);
+  boolean processCharWifi(char);
   void    processIncomingBoardMode(char);
   void    processIncomingSampleRate(char);
   void    processIncomingChannelSettings(char);
@@ -289,6 +290,7 @@ private:
   byte    xfer(byte);        // SPI Transfer function
 
   // Variables
+  boolean commandFromSPI;
   boolean firstDataPacket;
   boolean isProcessingIncomingSettingsChannel;
   boolean isProcessingIncomingSettingsLeadOff;

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,13 @@
 * Removed public `waitForNewChannelData()`
 * Removed public `timeSynced` and private `sendTimeSyncUpPacket`
 * Setting internal test signal now, when not streaming, returns a success message, with EOT `$$$`
+* Sending multi char messages now times out after a second of not completing the multichar message.
+
+## Release Candidate 6
+
+### Bug Fixes
+
+* Even when command came from wifi, library printed to `Serial0`, which resulted in overflow of radio buffer which led to a reset.
 
 ## Release Candidate 5
 

--- a/examples/BoardWithWifi/BoardWithWifi.ino
+++ b/examples/BoardWithWifi/BoardWithWifi.ino
@@ -50,7 +50,7 @@ void loop() {
     sdProcessChar(newChar);
 
     // Send to the board library
-    board.processChar(newChar);
+    board.processCharWifi(newChar);
   }
 
   if (!wifi.sentGains) {

--- a/examples/DefaultBoard/DefaultBoard.ino
+++ b/examples/DefaultBoard/DefaultBoard.ino
@@ -86,12 +86,11 @@ void loop() {
     sdProcessChar(newChar);
 
     // Send to the board library
-    board.processChar(newChar);
+    board.processCharWifi(newChar);
   }
 
   if (!wifi.sentGains) {
     if(wifi.present && wifi.tx) {
-      // Serial0.println("Synced with Wifi$$$");
       wifi.sendGains(board.numChannels, board.getGains());
     }
   }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_32bit_Library
-version=3.0.0-rc5
+version=3.0.0-rc6
 author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
 maintainer=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
 sentence=The library for controlling OpenBCI Cyton (32bit) boards. The Cyton is the main one.


### PR DESCRIPTION
## Release Candidate 6

### Bug Fixes

* Even when command came from wifi, library printed to `Serial0`, which resulted in overflow of radio buffer which led to a reset.