### PR TITLE
FIX: can stream rfduino data without having to take your wifi shield …

### DIFF
--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -193,6 +193,7 @@ public:
   void    startMultiCharCmdTimer(char);
   void    streamSafeChannelDeactivate(byte);
   void    streamSafeChannelActivate(byte);
+  void    streamSafeSetSampleRate(SAMPLE_RATE);
   void    streamSafeChannelSettingsForChannel(byte, byte, byte, byte, byte, byte, byte);
   void    streamSafeSetAllChannelsToDefault(void);
   void    streamSafeReportAllChannelDefaults(void);

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v3.1.0
+
+### Bug Fixes
+
+* Sending a start streaming command from `Serial0` when wifi was attached resulted in data flowing out over wifi, instead of flowing back to Serial0. If you had previous set your sample rate to 1000Hz to do WiFi, and then send a start stream command from Serial port, the board will ensure the sample rate is set to 250Hz.
+
 # v3.0.0
 
 ### New Features

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_32bit_Library
-version=3.0.1
+version=3.1.0
 author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
 maintainer=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
 sentence=The library for controlling OpenBCI Cyton (32bit) boards. The Cyton is the main one.

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=OpenBCI_32bit_Library
-version=3.0.0
+version=3.0.1
 author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
 maintainer=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
 sentence=The library for controlling OpenBCI Cyton (32bit) boards. The Cyton is the main one.
-paragraph=The to be ran on the Pic 32. Use the DefaultBoard.ino for the firmware that ships with every Cyton order. See the examples for stipped down versions of the board. See the learning pages at openbci.com for more info!
+paragraph=This library is designed to be ran on the Pic 32. Use the DefaultBoard.ino for the firmware that ships with every Cyton order. See the examples for stipped down versions of the board. See the learning pages at openbci.com for more info!
 category=Device Control
 url=https://github.com/OpenBCI/OpenBCI_32bit_Library
 architectures=pic32


### PR DESCRIPTION
# v3.1.0

### Bug Fixes

* Sending a start streaming command from `Serial0` when wifi was attached resulted in data flowing out over wifi, instead of flowing back to Serial0. If you had previous set your sample rate to 1000Hz to do WiFi, and then send a start stream command from Serial port, the board will ensure the sample rate is set to 250Hz.
