### PR TITLE
Fixed ACCEL_AXIS_* defines

### DIFF
--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -1472,13 +1472,13 @@ void OpenBCI_32bit_Library::sendRawAuxWifi(void) {
 void OpenBCI_32bit_Library::sendTimeWithAccelSerial(void) {
   // send two bytes of either accel data or blank
   switch (sampleCounter % 10) {
-    case ACCEL_AXIS_X: // 7
+    case ACCEL_AXIS_X: // 0
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_X);
       break;
-    case ACCEL_AXIS_Y: // 8
+    case ACCEL_AXIS_Y: // 1
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_Y);
       break;
-    case ACCEL_AXIS_Z: // 9
+    case ACCEL_AXIS_Z: // 2
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_Z);
       break;
     default:
@@ -1506,13 +1506,13 @@ void OpenBCI_32bit_Library::sendTimeWithAccelSerial(void) {
 void OpenBCI_32bit_Library::sendTimeWithAccelWifi(void) {
   // send two bytes of either accel data or blank
   switch (sampleCounter % 10) {
-    case ACCEL_AXIS_X: // 7
+    case ACCEL_AXIS_X: // 0
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_X);
       break;
-    case ACCEL_AXIS_Y: // 8
+    case ACCEL_AXIS_Y: // 1
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_Y);
       break;
-    case ACCEL_AXIS_Z: // 9
+    case ACCEL_AXIS_Z: // 2
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_Z);
       break;
     default:

--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -1472,13 +1472,13 @@ void OpenBCI_32bit_Library::sendRawAuxWifi(void) {
 void OpenBCI_32bit_Library::sendTimeWithAccelSerial(void) {
   // send two bytes of either accel data or blank
   switch (sampleCounter % 10) {
-    case ACCEL_AXIS_X: // 0
+    case ACCEL_AXIS_X: // 7
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_X);
       break;
-    case ACCEL_AXIS_Y: // 1
+    case ACCEL_AXIS_Y: // 8
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_Y);
       break;
-    case ACCEL_AXIS_Z: // 2
+    case ACCEL_AXIS_Z: // 9
       LIS3DH_writeAxisDataForAxisSerial(ACCEL_AXIS_Z);
       break;
     default:
@@ -1506,13 +1506,13 @@ void OpenBCI_32bit_Library::sendTimeWithAccelSerial(void) {
 void OpenBCI_32bit_Library::sendTimeWithAccelWifi(void) {
   // send two bytes of either accel data or blank
   switch (sampleCounter % 10) {
-    case ACCEL_AXIS_X: // 0
+    case ACCEL_AXIS_X: // 7
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_X);
       break;
-    case ACCEL_AXIS_Y: // 1
+    case ACCEL_AXIS_Y: // 8
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_Y);
       break;
-    case ACCEL_AXIS_Z: // 2
+    case ACCEL_AXIS_Z: // 9
       LIS3DH_writeAxisDataForAxisWifi(ACCEL_AXIS_Z);
       break;
     default:
@@ -3341,6 +3341,7 @@ void OpenBCI_32bit_Library::LIS3DH_writeAxisDataSerial(void){
 }
 
 void OpenBCI_32bit_Library::LIS3DH_writeAxisDataForAxisSerial(uint8_t axis) {
+  axis -= ACCEL_AXIS_X; // make sure we get a value in [0:2]
   if (axis > 2) axis = 0;
   writeSerial(highByte(axisData[axis])); // write 16 bit axis data MSB first
   writeSerial(lowByte(axisData[axis]));  // axisData is array of type short (16bit)
@@ -3354,6 +3355,7 @@ void OpenBCI_32bit_Library::LIS3DH_writeAxisDataWifi(void){
   }
 }
 void OpenBCI_32bit_Library::LIS3DH_writeAxisDataForAxisWifi(uint8_t axis) {
+  axis -= ACCEL_AXIS_X; // make sure we get a value in [0:2]
   if (axis > 2) axis = 0;
   wifi.storeByteBufTx(highByte(axisData[axis])); // write 16 bit axis data MSB first
   wifi.storeByteBufTx(lowByte(axisData[axis]));  // axisData is array of type short (16bit)

--- a/OpenBCI_32bit_Library_Definitions.h
+++ b/OpenBCI_32bit_Library_Definitions.h
@@ -197,9 +197,9 @@
 #define RATE_1600HZ_LP	0x80  //(b10000000)	// 1600Hz sample rate in low-power mode
 #define RATE_1250HZ_N	0x90  //(b10010000)	// 1250Hz sample rate in normal mode
 #define RATE_5000HZ_LP	0x90  //(b10010000)	// 5000Hz sample rate in low-power mode
-#define ACCEL_AXIS_X    0x00 // x axis
-#define ACCEL_AXIS_Y    0x01 // y axis
-#define ACCEL_AXIS_Z    0x02 // z axis
+#define ACCEL_AXIS_X    0x07 // x axis
+#define ACCEL_AXIS_Y    0x08 // y axis
+#define ACCEL_AXIS_Z    0x09 // z axis
 
 // OPENBCI_COMMANDS
 /** Turning channels off */

--- a/OpenBCI_32bit_Library_Definitions.h
+++ b/OpenBCI_32bit_Library_Definitions.h
@@ -197,9 +197,9 @@
 #define RATE_1600HZ_LP	0x80  //(b10000000)	// 1600Hz sample rate in low-power mode
 #define RATE_1250HZ_N	0x90  //(b10010000)	// 1250Hz sample rate in normal mode
 #define RATE_5000HZ_LP	0x90  //(b10010000)	// 5000Hz sample rate in low-power mode
-#define ACCEL_AXIS_X    0x07 // x axis
-#define ACCEL_AXIS_Y    0x08 // y axis
-#define ACCEL_AXIS_Z    0x09 // z axis
+#define ACCEL_AXIS_X    0x00 // x axis
+#define ACCEL_AXIS_Y    0x01 // y axis
+#define ACCEL_AXIS_Z    0x02 // z axis
 
 // OPENBCI_COMMANDS
 /** Turning channels off */


### PR DESCRIPTION
The previous values were not working because 'LIS3DH_writeAxisDataForAxisSerial' and 'LIS3DH_writeAxisDataForAxisWifi' truncate values > 2, ie:
if (axis > 2) axis = 0;

Therefore, the value sent was always the 'X' channel. 

However, I have not builded and flashed my firmware yet, so this fix should be validated. In particular, is the accel data available at frames 0, 1 & 2? Or was the value of ACCEL_AXIS_* specifically at 7, 8 & 9 to let the time to get accel sensor data ? Anyway, the current implementation is broken and should be fixed.